### PR TITLE
Revert "Number sequential delayed job workers"

### DIFF
--- a/delayed_job/recipes/template.rb
+++ b/delayed_job/recipes/template.rb
@@ -18,7 +18,7 @@ node[:deploy].each do |application, deploy|
           :timeout => dj[:timeout] || global[:timeout],
           :bin => dj[:bin] || global[:bin],
           :identifier => identifier,
-          :suffix => ".#{index}",
+          :suffix => ".#{identifier}",
           :options => dj[:options] || global[:options]
         }
       end


### PR DESCRIPTION
This reverts commit a7c78ce8d6574073fdbcdcf334bb6ee9f4ae33b5.

Worker count is incompatible with identifier

If you use a worker count it overrides the identifier you provide.