### PR TITLE
Protect against CLRF injection in unicorn nginx

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -57,10 +57,10 @@ server {
     proxy_redirect off;
 
     <% if @application[:force_ssl] %>
-    set $https_forward "https://$host$uri";
+    set $https_forward "https://$host$request_uri";
     # Don't disclose private IP addresses when no host specified (HTTP/1.0)
     if ($host ~ "\d+\.\d+\.\d+\.\d+") {
-      set $https_forward "https://<%= @application[:domains].first %>$uri";
+      set $https_forward "https://<%= @application[:domains].first %>$request_uri";
     }
 
     # Rewrite everything to HTTPS. Except for the health_check.


### PR DESCRIPTION
Our current configuration is vulnerable to CRLF injection whenever we
perform a rewrite, which currently includes the `$uri` directive. `$uri`
attempts to parse and decode the uri, including encoded CRLF characters.
This allows an attacker to insert arbitrary header values.

We fix this by using `$request_uri` instead of `$uri`, which does not
attempt any sort of parsing.